### PR TITLE
Release 5 0 2 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <!-- fork of https://github.com/pac4j/vertx-pac4j for using Vert.x 4 -->
   <groupId>org.pac4j</groupId>
   <artifactId>vertx-pac4j</artifactId>
-  <version>5.0.2-FOLIO.1</version>
+  <version>5.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>vertx-pac4j FOLIO fork, Vert.x 4</name>
@@ -14,7 +14,7 @@
     <url>https://github.com/folio-org/vertx-pac4j.git</url>
     <connection>scm:git:git@github.com:folio-org/vertx-pac4j.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/vertx-pac4j.git</developerConnection>
-    <tag>v5.0.2-FOLIO.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <!-- fork of https://github.com/pac4j/vertx-pac4j for using Vert.x 4 -->
   <groupId>org.pac4j</groupId>
   <artifactId>vertx-pac4j</artifactId>
-  <version>5.0.2-SNAPSHOT</version>
+  <version>5.0.2-FOLIO.1</version>
   <packaging>jar</packaging>
 
   <name>vertx-pac4j FOLIO fork, Vert.x 4</name>
@@ -14,6 +14,7 @@
     <url>https://github.com/folio-org/vertx-pac4j.git</url>
     <connection>scm:git:git@github.com:folio-org/vertx-pac4j.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/vertx-pac4j.git</developerConnection>
+    <tag>v5.0.2-FOLIO.1</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.0.2</vertx.version>
+    <vertx.version>4.0.3</vertx.version>
     <pac4j.version>4.3.1</pac4j.version>
     <java.version>1.8</java.version>
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>


### PR DESCRIPTION
I dared including from Vert.x 4.0.2 to 4.0.3. Base branch renamed from vertx-4-0-2-folio to vertx-4-folio as we are going to probably update to newer versions eg 4.1.0 later. Upstream vertx-pac4j also has started to use pac4j 4.5.0, but this is NOT done yet, as we should minimize changes for R1 hotfix.

This was tested with mod-login-saml where I removed VertxWebContext2.